### PR TITLE
Create a new NFC session when the old one is invalidated.

### DIFF
--- a/NFC-Example/Info.plist
+++ b/NFC-Example/Info.plist
@@ -20,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NFCReaderUsageDescription</key>
+	<string>NFC Test</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -33,6 +35,7 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
@@ -41,7 +44,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NFCReaderUsageDescription</key>
-	<string>NFC Test</string>
 </dict>
 </plist>

--- a/NFC-Example/Source/NFCTableViewController.swift
+++ b/NFC-Example/Source/NFCTableViewController.swift
@@ -24,15 +24,19 @@ class NFCTableViewController: UITableViewController {
         self.nfcSession.begin()
     }
     
+    func initializeNFCSession() {
+        // Create the NFC Reader Session when the app starts
+        self.nfcSession = NFCNDEFReaderSession(delegate: self, queue: DispatchQueue.main, invalidateAfterFirstRead: false)
+        self.nfcSession.alertMessage = "You can scan NFC-tags by holding them behind the top of your iPhone."
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
         // Register our table-cell to display the records
         self.tableView.register(NFCTableViewCell.self, forCellReuseIdentifier: "NFCTableCell")
         
-        // Create the NFC Reader Session when the app starts
-        self.nfcSession = NFCNDEFReaderSession(delegate: self, queue: DispatchQueue.main, invalidateAfterFirstRead: false)
-        self.nfcSession.alertMessage = "You can scan NFC-tags by holding them behind the top of your iPhone."
+        self.initializeNFCSession()
     }
     
     class func formattedTypeNameFormat(from typeNameFormat: NFCTypeNameFormat) -> String {
@@ -105,6 +109,8 @@ extension NFCTableViewController : NFCNDEFReaderSessionDelegate {
     // Called when the reader-session expired, you invalidated the dialog or accessed an invalidated session
     func readerSession(_ session: NFCNDEFReaderSession, didInvalidateWithError error: Error) {
         print("NFC-Session invalidated: \(error.localizedDescription)")
+        // initialize a new session
+        self.initializeNFCSession()
     }
     
     // Called when a new set of NDEF messages is found


### PR DESCRIPTION
According to Apple's documentation, when a reader session is invalidated,
it is closed and subsequently no longer reusable:

https://developer.apple.com/documentation/corenfc/nfcreadersessionprotocol/2874107-invalidate

This is the cause of #1 in the `User Experiences` remarks.

```
Scanning an NDEF-tag usually works once directly after rebooting the iPhone. From then on, it may or may not work, usually it doesn't work and another reboot is required. This was seen with Beta 1-4 of iOS 11.
```

My workaround (which I think is the expected use) is to initialize a new
session when the other one is invalidated.

Now you can scan as many times as you'd like without having to quit the app, yay!